### PR TITLE
Custom tokenizer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3753,6 +3753,11 @@
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
       "dev": true
     },
+    "xregexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
+      "integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg=="
+    },
     "xtend": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "ramda": "^0.25.0",
     "union-type": "^0.4.1",
     "unorm": "^1.4.1",
-    "urlencoded-body-parser": "^2.0.1"
+    "urlencoded-body-parser": "^2.0.1",
+    "xregexp": "^4.0.0"
   },
   "devDependencies": {
     "eslint": "^4.15.0",

--- a/src/interval.js
+++ b/src/interval.js
@@ -49,9 +49,12 @@ Interval.prototype.overlaps = function(interval) {
   }, this)
 }
 
-Interval.prototype.expand = function(i) {
+Interval.prototype.expand = function() {
   return Interval.case({
-    Interval: () => Interval.Interval(this[0] - i, this[1] + i),
+    Interval: () => {
+      const i = Math.min(Math.ceil(this.length() / 2.0), 50)
+      return Interval.Interval(this[0] - i, this[1] + i)
+    },
     InvalidInterval: () => Interval.InvalidInterval
   }, this)
 }

--- a/src/label.js
+++ b/src/label.js
@@ -1,14 +1,12 @@
 "use strict";
 
 const TextIndex = require('./textindex')
-    , { convertToRomanNumerals
-      , filterCombiningCharacters } = require('./utils')
 
 module.exports = {
   index: docs => {
     const index = TextIndex(
       { fields: ['label', 'localizedLabels']
-      , filters: [filterCombiningCharacters, convertToRomanNumerals]
+      , filters: ['filterCombiningCharacters']
       , stopwords: ['period', 'age']
       , stopchars: ['.']
       }

--- a/src/label.js
+++ b/src/label.js
@@ -6,9 +6,30 @@ module.exports = {
   index: docs => {
     const index = TextIndex(
       { fields: ['label', 'localizedLabels']
-      , filters: ['filterCombiningCharacters']
-      , stopwords: ['period', 'age']
-      , stopchars: ['.']
+      , stopwords: [
+          'a',
+          'ad',
+          'age',
+          'and',
+          'b',
+          'bc',
+          'bce',
+          'c',
+          'ca',
+          'd',
+          'epoch',
+          'era',
+          'for',
+          'in',
+          'of',
+          'or',
+          'period',
+          'periods',
+          'the',
+          'to',
+          'with',
+          'years'
+        ]
       }
     )
     docs.forEach(doc => index.addDoc(doc))

--- a/src/label.js
+++ b/src/label.js
@@ -1,21 +1,18 @@
 "use strict";
 
-const TextIndex = require('elasticlunr')
+const TextIndex = require('./textindex')
     , { convertToRomanNumerals
-      , filterCombiningCharacters
-      , stopwords, removeCharacters } = require('./utils')
+      , filterCombiningCharacters } = require('./utils')
 
 module.exports = {
   index: docs => {
-    const index = TextIndex(function() {
-      this.addField('label')
-      this.addField('localizedLabels')
-      this.pipeline.reset()
-      this.pipeline.add(stopwords(['period', 'age']))
-      this.pipeline.add(filterCombiningCharacters)
-      this.pipeline.add(convertToRomanNumerals)
-      this.pipeline.add(removeCharacters(['.']))
-    })
+    const index = TextIndex(
+      { fields: ['label', 'localizedLabels']
+      , filters: [filterCombiningCharacters, convertToRomanNumerals]
+      , stopwords: ['period', 'age']
+      , stopchars: ['.']
+      }
+    )
     docs.forEach(doc => index.addDoc(doc))
 
     return { search: query => index.search(query,

--- a/src/reconcile.js
+++ b/src/reconcile.js
@@ -1,16 +1,12 @@
 "use strict";
 
 const R = require('ramda')
-    , elasticlunr = require('elasticlunr')
     , label = require('./label')
     , spatial = require('./spatial')
     , temporal = require('./temporal')
     , schulze = require('./schulze')
     , format = require('./format')
     , { DEFAULT_TYPE, WEIGHTS } = require('./consts')
-
-// elasticlunr tokenizer is global, so we configure it here!
-elasticlunr.tokenizer.setSeperator(/[\s\-,:()]+|\d{3,}|[3-9]\d|2[1-9]/)
 
 const parseProperties = properties => properties
   ? R.fromPairs(properties.map(({p, pid, v}) => [p || pid, v]))

--- a/src/spatial.js
+++ b/src/spatial.js
@@ -1,16 +1,14 @@
 "use strict";
 
-const TextIndex = require('elasticlunr')
-    , { stopwords } = require('./utils')
+const TextIndex = require('./textindex')
 
 module.exports = {
   index: docs => {
-    const index = TextIndex(function() {
-      this.addField('spatialCoverage')
-      this.addField('spatialCoverageDescription')
-      this.pipeline.reset()
-      this.pipeline.add(stopwords(['and', 'or']))
-    })
+    const index = TextIndex(
+      { fields: ['spatialCoverage', 'spatialCoverageDescription']
+      , stopwords: ['and', 'or']
+      }
+    )
     docs.forEach(doc => index.addDoc(doc))
 
     return { search: query => index.search(query,

--- a/src/spatial.js
+++ b/src/spatial.js
@@ -6,7 +6,7 @@ module.exports = {
   index: docs => {
     const index = TextIndex(
       { fields: ['spatialCoverage', 'spatialCoverageDescription']
-      , stopwords: ['and', 'or']
+      , stopwords: ['and', 'or', 'of', 'in']
       }
     )
     docs.forEach(doc => index.addDoc(doc))

--- a/src/temporal.js
+++ b/src/temporal.js
@@ -45,8 +45,8 @@ class IntervalIndex {
         if (s > 0) {
           return results.concat([{ref: id, score: s}])
         }
-        // try again with a 100-year buffer for half the score
-        s = score(query, interval.expand(100)) / 2.0
+        // try again with expanded interval buffer for half the score
+        s = score(query, interval.expand()) / 2.0
         return s > 0
           ? results.concat([{ref: id, score: s}])
           : results

--- a/src/textindex.js
+++ b/src/textindex.js
@@ -1,0 +1,59 @@
+"use strict";
+
+const R = require('ramda')
+    , elasticlunr = require('elasticlunr')
+    , tokenize = require('./tokenize')
+    , {convertToRomanNumerals, filterCombiningCharacters} = require('./utils')
+
+const register = (f, name) => {
+  delete elasticlunr.Pipeline.registeredFunctions[name]
+  elasticlunr.Pipeline.registerFunction(f, name)
+  return f
+}
+
+const removeWords = words => {
+  const words_has = R.fromPairs(words.map(x => [x, true]))
+  const filter = token => words_has[token] ? undefined : token
+  return register(filter, words.join('|'))
+}
+
+const SPECIAL_CHARS = '^$\\.*+?()[]{}`'
+
+const escape = c => SPECIAL_CHARS.includes(c) ? `\\${c}` : c
+
+const removeChars = chars => {
+  const filter = token => token.replace(
+    RegExp(`[${chars.map(escape).join('')}]+`, 'g'), '')
+  return register(filter, chars.join(''))
+}
+
+elasticlunr.tokenizer = tokenize
+
+register(convertToRomanNumerals, 'convertToRomanNumerals')
+register(filterCombiningCharacters, 'filterCombiningCharacters')
+
+module.exports = ({fields, filters, stopwords, stopchars}) => {
+  const index = new elasticlunr.Index
+
+  for (const field of (fields)) {
+    index.addField(field)
+  }
+
+  index.pipeline.reset()
+
+  if (stopwords) {
+    index.pipeline.add(removeWords(stopwords))
+  }
+
+  if (filters) {
+    for (const filter of filters) {
+      index.pipeline.add(filter)
+    }
+  }
+
+  if (stopchars) {
+    index.pipeline.add(removeChars(stopchars))
+  }
+
+  return index
+}

--- a/src/textindex.js
+++ b/src/textindex.js
@@ -2,7 +2,6 @@
 
 const R = require('ramda')
     , elasticlunr = require('elasticlunr')
-    , unorm = require('unorm')
     , tokenize = require('./tokenize')
 
 const register = (f, name) => {
@@ -11,34 +10,16 @@ const register = (f, name) => {
   return f
 }
 
-// http://www.unicode.org/charts/PDF/U0300.pdf
-const COMBINING_CHARACTERS_REGEX = /[\u0300-\u036f]/g
-
-function filterCombiningCharacters(token) {
-  return unorm.nfd(token).replace(COMBINING_CHARACTERS_REGEX, '')
-}
-
 const removeWords = words => {
   const words_has = R.fromPairs(words.map(x => [x, true]))
   const filter = token => words_has[token] ? undefined : token
   return register(filter, words.join('|'))
 }
 
-const SPECIAL_CHARS = '^$\\.*+?()[]{}`'
-
-const escape = c => SPECIAL_CHARS.includes(c) ? `\\${c}` : c
-
-const removeChars = chars => {
-  const filter = token => token.replace(
-    RegExp(`[${chars.map(escape).join('')}]+`, 'g'), '')
-  return register(filter, chars.join(''))
-}
-
 // global elasticlunr configuration
 elasticlunr.tokenizer = tokenize
-register(filterCombiningCharacters, 'filterCombiningCharacters')
 
-module.exports = ({fields, filters, stopwords, stopchars}) => {
+module.exports = ({fields, stopwords}) => {
   const index = new elasticlunr.Index
 
   for (const field of (fields)) {
@@ -49,16 +30,6 @@ module.exports = ({fields, filters, stopwords, stopchars}) => {
 
   if (stopwords) {
     index.pipeline.add(removeWords(stopwords))
-  }
-
-  if (filters) {
-    for (const filter of filters) {
-      index.pipeline.add(elasticlunr.Pipeline.registeredFunctions[filter])
-    }
-  }
-
-  if (stopchars) {
-    index.pipeline.add(removeChars(stopchars))
   }
 
   return index

--- a/src/tokenize.js
+++ b/src/tokenize.js
@@ -1,14 +1,64 @@
 "use strict";
 
 const R = require('ramda')
+    , re = require('xregexp');
 
-const SEPARATOR = /[\s\-,:()]+|\d{3,}|[3-9]\d|2[1-9]/
+const SEPARATOR = re(
+`\\s+(?!           # spaces, except before:
+   (?:\\b
+     (?:i{1,3}|v|x{1,2}){1,3}  # Roman numerals
+     (?:[abc](?:[123])?)?      # possibly with letter/number suffixes
+   \\b)
+ )
+ | [\\-,:()]+      # other separating punctuation
+ | \\b\\d{2,4}\\b  # years, maybe
+`, 'x');
+
+// e.g. ['early', 'bronze'] => ['early bronze']
+const MODIFIERS = ['early', 'middle', 'late']
+const prependModifiers = R.pipe(
+  R.reduce(
+    ({prepend, tokens}, token) => {
+      const t = `${prepend ? (prepend + ' ') : ''}${token}`
+      return MODIFIERS.includes(token)
+        ? {prepend: t, tokens}
+        : {tokens: R.append(t, tokens)}
+    },
+    {tokens: []}
+  ),
+  ({prepend, tokens}) => prepend ? R.append(prepend, tokens) : tokens
+)
+
+const ROMAN_NUMERALS = [
+  '',
+  'i',
+  'ii',
+  'iii',
+  'iv',
+  'v',
+  'vi',
+  'vii',
+  'viii',
+  'ix',
+]
+
+function arabicToRoman(token) {
+  const int = parseInt(token, 10)
+  if (isNaN(int) || int < 1 || int > 9) {
+    return token
+  } else {
+    return ROMAN_NUMERALS[int]
+  }
+}
 
 const tokenizeString = R.pipe(
   s => '' + s,
   R.trim,
   R.toLower,
-  R.split(SEPARATOR)
+  R.replace(/\b[1-9]\b/, arabicToRoman),
+  R.split(SEPARATOR),
+  R.reject(R.isEmpty),
+  prependModifiers
 )
 
 module.exports = s => (

--- a/src/tokenize.js
+++ b/src/tokenize.js
@@ -1,38 +1,8 @@
 "use strict";
 
 const R = require('ramda')
-    , re = require('xregexp');
-
-const SEPARATOR = re(
-`\\s+(?!           # spaces, except before:
-   (?:\\b
-     (?:
-       (?:
-         (?:i{1,3}|v|x{1,2}){1,3}  # Roman numerals
-         (?:[abc](?:[123])?)?      # possibly with letter/number suffixes
-       )
-       | wars?                     # or "war[s]"
-     )
-   \\b)
- )
- | [\\-,:()]+      # other separating punctuation
- | \\b\\d{2,4}\\b  # years, maybe
-`, 'x');
-
-// e.g. ['early', 'bronze'] => ['early bronze']
-const MODIFIERS = ['early', 'middle', 'late']
-const prependModifiers = R.pipe(
-  R.reduce(
-    ({prepend, tokens}, token) => {
-      const t = `${prepend ? (prepend + ' ') : ''}${token}`
-      return MODIFIERS.includes(token)
-        ? {prepend: t, tokens}
-        : {tokens: R.append(t, tokens)}
-    },
-    {tokens: []}
-  ),
-  ({prepend, tokens}) => prepend ? R.append(prepend, tokens) : tokens
-)
+    , re = require('xregexp')
+    , unorm = require('unorm')
 
 const ROMAN_NUMERALS = [
   '',
@@ -56,14 +26,99 @@ function arabicToRoman(token) {
   }
 }
 
+const SEPARATOR = re(
+`[\\s:/]+                         # whitespace, colons, or slashes,
+ (?!                               # except before
+   (?:\\b                          # words
+     (?:                           # that:
+       (?:                         # 1) consist of
+         (?:i{1,3}|v|x{1,2}){1,3}  #    Roman numerals
+         (?:[abc](?:[123])?)?      #    (possibly with letter/number suffixes)
+       )                           # or
+       | campaigns?                # 2) are period category terms
+       | colon(?:y|ies)
+       | conflicts?
+       | conquests?
+       | dynast(?:y|ies)
+       | empires?
+       | expeditions?
+       | insurrections?
+       | interventions?
+       | invasions?
+       | kingdoms?
+       | monarch(?:y|ies)
+       | movements?
+       | occupations?
+       | rebellions?
+       | republics?
+       | restorations?
+       | revolts?
+       | revolutions?
+       | rule
+       | uprisings?
+       | wars?
+     )
+   \\b)
+ )
+`, 'x')
+
+// e.g. ['early', 'bronze'] => ['early bronze']
+const MODIFIERS = re(
+`^
+(?:
+  1st
+| 2nd
+| 3rd
+| ancient
+| anglo
+| cypro
+| earl(?:y|ier)
+| east(?:ern)?
+| first
+| french
+| great
+| greco
+| king
+| later?
+| middle
+| ne(?:o|w)
+| north(?:ern)?
+| old
+| post
+| pre
+| romano?
+| south(?:ern)?
+| spanish
+| west(?:ern)?
+| \\d+th
+)
+$`, 'x')
+const prependModifiers = R.pipe(
+  R.reduce(
+    ({prepend, tokens}, token) => {
+      const t = `${prepend ? (prepend + ' ') : ''}${token}`
+      return token.match(MODIFIERS)
+        ? {prepend: t, tokens}
+        : {tokens: R.append(t, tokens)}
+    },
+    {tokens: []}
+  ),
+  ({prepend, tokens}) => prepend ? R.append(prepend, tokens) : tokens
+)
+
 const tokenizeString = R.pipe(
   s => '' + s,
-  R.trim,
-  R.toLower,
-  R.replace(/\b[1-9]\b/, arabicToRoman),
-  R.split(SEPARATOR),
-  R.reject(R.isEmpty),
-  prependModifiers
+  R.trim,                                 // trim whitespace
+  unorm.nfd,                              // normalize unicode
+  R.toLower,                              // lowercase
+  R.replace(/[\u0300-\u036f]/g, ''),      // remove combining characters
+  R.replace(/-/g, ' '),                   // replace hyphens with spaces
+  R.replace(/[!-.;-@[-`{-~]+/g, ''),      // remove punctuation
+  R.replace(/\b[1-9]\b/g, arabicToRoman), // 1 -> i, 2 -> ii, etc.
+  R.replace(/\b\d+\b/g, ''),              // remove remaining all-digit words
+  R.split(SEPARATOR),                     // split into tokens
+  R.reject(R.isEmpty),                    // filter out empty tokens
+  prependModifiers                        // include e.g. 'early' in next token
 )
 
 module.exports = s => (

--- a/src/tokenize.js
+++ b/src/tokenize.js
@@ -1,63 +1,20 @@
 "use strict";
 
+const R = require('ramda')
 
-const PHASE_QUALIFIERS = [
-  /^early/i,
-  /^(mid|middle)/i,
-  /^late/i,
-]
+const SEPARATOR = /[\s\-,:()]+|\d{3,}|[3-9]\d|2[1-9]/
 
-const SUFFIXES = [
-  /age$/i,
-  /era$/i,
-  /empire$/i,
-  /phase$/i,
-  /period$/i,
-  /dynasty$/i,
-]
+const tokenizeString = R.pipe(
+  s => '' + s,
+  R.trim,
+  R.toLower,
+  R.split(SEPARATOR)
+)
 
-const NUMBERING = [
-  /\b(\d|I|II|III|IV|V|VI|VII|VIII|IX)(A|B|C|D)?$/,
-  /\b(A)()$/i,
-  /\b(B)()$/i,
-  /\b(C)()$/i,
-  /\b(D)()$/i,
-]
-
-function matchFirst(regexes, query) {
-  for (let i = 0; i < regexes.length; i++) {
-    const regex = regexes[i]
-        , match = regex.exec(query)
-
-    if (match) return { match, regex }
-  }
-
-  return null;
-}
-
-module.exports = function tokenize(string) {
-  let label = string
-    , phase
-    , suffix
-    , numbering
-
-  const phaseMatch = matchFirst(PHASE_QUALIFIERS, label);
-  if (phaseMatch) {
-    phase = phaseMatch.match[0];
-    label = label.replace(phaseMatch.regex, '').trim();
-  }
-
-  const numberingMatch = matchFirst(NUMBERING, label);
-  if (numberingMatch) {
-    numbering = numberingMatch.match[0];
-    label = label.replace(numberingMatch.regex, '').trim();
-  }
-
-  const suffixMatch = matchFirst(SUFFIXES, label);
-  if (suffixMatch) {
-    suffix = suffixMatch.match[0];
-    label = label.replace(suffixMatch.regex, '').trim();
-  }
-
-  return { originalLabel: string, label, phase, suffix, numbering }
-}
+module.exports = s => (
+  R.isNil(s)
+    ? []
+    : Array.isArray(s)
+      ? R.chain(tokenizeString, R.reject(R.isNil, s))
+      : tokenizeString(s)
+)

--- a/src/tokenize.js
+++ b/src/tokenize.js
@@ -6,8 +6,13 @@ const R = require('ramda')
 const SEPARATOR = re(
 `\\s+(?!           # spaces, except before:
    (?:\\b
-     (?:i{1,3}|v|x{1,2}){1,3}  # Roman numerals
-     (?:[abc](?:[123])?)?      # possibly with letter/number suffixes
+     (?:
+       (?:
+         (?:i{1,3}|v|x{1,2}){1,3}  # Roman numerals
+         (?:[abc](?:[123])?)?      # possibly with letter/number suffixes
+       )
+       | wars?                     # or "war[s]"
+     )
    \\b)
  )
  | [\\-,:()]+      # other separating punctuation

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,7 +2,6 @@
 
 const R = require('ramda')
     , { readFileSync } = require('fs')
-    , unorm = require('unorm')
 
 // scoring: [{ref: 'foo', score: 0.7}, {ref: 'bar', score: 1.1}]
 // scores: {foo: 0.7, bar: 1.1}
@@ -37,51 +36,9 @@ const pairwisePreferences = (scorings, weights, choices) => {
   )
 }
 
-// http://www.unicode.org/charts/PDF/U0300.pdf
-const COMBINING_CHARACTERS_REGEX = /[\u0300-\u036f]/g
-
-function filterCombiningCharacters(token) {
-  return unorm.nfd(token).replace(COMBINING_CHARACTERS_REGEX, '')
-}
-
-// "or at most 1-20 -- no one has phase numbering beyond 20" -- Adam
-const ROMAN_NUMERALS = [
-  '',
-  'i',
-  'ii',
-  'iii',
-  'iv',
-  'v',
-  'vi',
-  'vii',
-  'viii',
-  'ix',
-  'x',
-  'xi',
-  'xii',
-  'xiii',
-  'xiv',
-  'xv',
-  'xvi',
-  'xvii',
-  'xviii',
-  'xix',
-  'xx',
-]
-
-function convertToRomanNumerals(token) {
-  const int = parseInt(token, 10)
-  if (isNaN(int) || int < 1 || int > 20) {
-    return token
-  } else {
-    return ROMAN_NUMERALS[int]
-  }
-}
-
 const loadJSON = path => JSON.parse(readFileSync(path, 'utf8'))
 
 module.exports = {
   pairwisePreferences,
-  loadJSON,
-  filterCombiningCharacters,
-  convertToRomanNumerals }
+  loadJSON
+}

--- a/test/interval.js
+++ b/test/interval.js
@@ -107,8 +107,14 @@ test('invalid intervals overlap nothing', t => {
   t.equal(interval.overlaps(interval), 0)
 })
 
-test('expanding intervals', t => {
-  const interval = Interval.Interval(600, 1000)
-  t.plan(1)
-  t.deepEqual(interval.expand(50), Interval.Interval(550, 1050))
+test('expand broadens x2, up to 100', t => {
+  const interval401 = Interval.Interval(600, 1000)
+  const interval41 = Interval.Interval(60, 100)
+  const interval5 = Interval.Interval(6, 10)
+  const interval4 = Interval.Interval(6, 9)
+  t.plan(4)
+  t.deepEqual(interval401.expand(), Interval.Interval(550, 1050))
+  t.deepEqual(interval41.expand(), Interval.Interval(39, 121))
+  t.deepEqual(interval5.expand(), Interval.Interval(3, 13))
+  t.deepEqual(interval4.expand(), Interval.Interval(4, 11))
 })

--- a/test/label.js
+++ b/test/label.js
@@ -189,8 +189,9 @@ test('should understand Roman numerals as equivalent to Arabic numerals', t => {
   t.same(results.map(({ref}) => ref), ['rank0', 'rank1', 'rank2'])
 })
 
-test('should ignore periods', t => {
+test('should ignore BC', t => {
   const docs = [
+    {id: 'unranked', label: '1200 BC Middle East'},
     {id: 'rank0', label: 'Athenian supremacy, 479-431 B.C'},
   ]
   const results = label.index(docs).search('Athenian supremacy, 479-431 B.C.')
@@ -252,6 +253,27 @@ test('"wars" is not a separate token', t => {
     {id: 'rank0', label: 'Civil Wars'},
   ]
   const results = label.index(docs).search('Civil Wars')
+  t.plan(1)
+  t.same(results.map(({ref}) => ref), ['rank0'])
+})
+
+test('"of" is a stopword', t => {
+  const docs = [
+    {id: 'unranked', label: 'Revolt of Sertorius'},
+    {id: 'rank0', label: 'Age of Tyrants'},
+  ]
+  const results = label.index(docs).search('Age of Tyrants')
+  t.plan(1)
+  t.same(results.map(({ref}) => ref), ['rank0'])
+})
+
+test('hyphenated and unhyphenated versions of modifiers should match', t => {
+  const docs = [
+    {id: 'unranked1', label: 'Babylonian'},
+    {id: 'unranked2', label: 'Neo'},
+    {id: 'rank0', label: 'Neo Babylonian'},
+  ]
+  const results = label.index(docs).search('Neo-Babylonian')
   t.plan(1)
   t.same(results.map(({ref}) => ref), ['rank0'])
 })

--- a/test/label.js
+++ b/test/label.js
@@ -33,27 +33,27 @@ test('sanity test 1', t => {
   t.same(results.map(({ref}) => ref), ['rank0', 'rank1'])
 })
 
-test('sanity test 2', t => {
+test('parts and modifiers must match 1', t => {
   const docs = [
-    {id: 'rank2', label: 'Early Bronze III'},
-    {id: 'rank1', label: 'Early Bronze'},
+    {id: 'unranked1', label: 'Early Bronze III'},
+    {id: 'unranked2', label: 'Early Bronze'},
     {id: 'rank0', label: 'Bronze'}
   ]
   const results = label.index(docs).search('Bronze')
   t.plan(1)
-  t.same(results.map(({ref}) => ref), ['rank0', 'rank1', 'rank2'])
+  t.same(results.map(({ref}) => ref), ['rank0'])
 })
 
-test('sanity test 3', t => {
+test('parts and modifiers must match 2', t => {
   const docs = [
-    {id: 'rank1', label: 'Early Bronze III'},
+    {id: 'unranked1', label: 'Early Bronze III'},
     {id: 'rank0', label: 'Early Bronze'},
-    {id: 'rank2', label: 'Bronze'},
-    {id: 'rank3', label: 'Early Curly'},
+    {id: 'unranked2', label: 'Bronze'},
+    {id: 'unranked3', label: 'Early Curly'},
   ]
   const results = label.index(docs).search('Early Bronze')
   t.plan(1)
-  t.same(results.map(({ref}) => ref), ['rank0', 'rank1', 'rank2', 'rank3'])
+  t.same(results.map(({ref}) => ref), ['rank0'])
 })
 
 test('sanity test 4', t => {
@@ -76,10 +76,10 @@ test('sanity test 5', t => {
   t.same(results.map(({ref}) => ref), ['rank0', 'rank1'])
 })
 
-test('sanity test 6', t => {
+test('appended temporal range is ignored', t => {
   const docs = [
-    {id: 'rank1', label: 'Alexander, 1501-1506'},
-    {id: 'rank0', label: 'Alexander'}
+    {id: 'rank0', label: 'Alexander, 1501-1506'},
+    {id: 'rank1', label: 'Alexander'}
   ]
   const results = label.index(docs).search('alexander')
   t.plan(1)
@@ -127,7 +127,7 @@ test('chinese', t => {
 
 test('weird LCSH syntax', t => {
   const docs = [
-    {id: 'rank1', label: '18th Century::2nd/3rd quarter (1725 - 1774'},
+    {id: 'rank1', label: '18th Century::2nd/3rd quarter (1725 - 1774)'},
     {id: 'rank0', label: '18th Century'}
   ]
   const results = label.index(docs).search('18th century')
@@ -135,50 +135,38 @@ test('weird LCSH syntax', t => {
   t.same(results.map(({ref}) => ref), ['rank0', 'rank1'])
 })
 
-test('should match at least one token in label', t=> {
+test('should match with special modifier/suffix tokenizing', t=> {
   const docs = [
-    {id: 'rank1', label: 'Late Helladic'},
-    {id: 'rank2', label: 'Late Cycladic'},
+    {id: 'unranked1', label: 'Late Helladic'},
+    {id: 'unranked2', label: 'Late Cycladic'},
     {id: 'rank0', label: 'Late Helladic IIIA'},
-    {id: 'unranked', label: 'Early Cycladic'},
+    {id: 'unranked3', label: 'Early Cycladic'},
   ]
   const results = label.index(docs).search('Late Helladic IIIA')
   t.plan(1)
-  t.same(results.map(({ref}) => ref), ['rank0', 'rank1', 'rank2'])
-})
-
-test('should match at least one token in localized labels', t=> {
-  const docs = [
-    {id: 'rank1', localizedLabels: 'Late Helladic'},
-    {id: 'rank2', localizedLabels: 'Late Cycladic'},
-    {id: 'rank0', localizedLabels: 'Late Helladic IIIA'},
-    {id: 'unranked', localizedLabels: 'Early Cycladic'},
-  ]
-  const results = label.index(docs).search('Late Helladic IIIA')
-  t.plan(1)
-  t.same(results.map(({ref}) => ref), ['rank0', 'rank1', 'rank2'])
+  t.same(results.map(({ref}) => ref), ['rank0'])
 })
 
 test('should ignore `period`', t=> {
   const docs = [
     {id: 'rank0', label: 'Late Helladic'},
-    {id: 'rank1', label: 'Late Cycladic'},
-    {id: 'unranked', label: 'Cycladic Period'},
+    {id: 'unranked1', label: 'Late Cycladic'},
+    {id: 'unranked2', label: 'Cycladic Period'},
   ]
   const results = label.index(docs).search('Late Helladic Period')
   t.plan(1)
-  t.same(results.map(({ref}) => ref), ['rank0', 'rank1'])
+  t.same(results.map(({ref}) => ref), ['rank0'])
 })
 
 test('should ignore `age`', t=> {
   const docs = [
-    {id: 'unranked', label: 'Iron Age'},
-    {id: 'rank1', label: 'Bronze Age'},
+    {id: 'unranked1', label: 'Iron Age'},
+    {id: 'unranked2', label: 'Bronze Age'},
     {id: 'rank0', label: 'Late Bronze'},
   ]
   const results = label.index(docs).search('Late Bronze Age')
   t.plan(1)
-  t.same(results.map(({ref}) => ref), ['rank0', 'rank1'])
+  t.same(results.map(({ref}) => ref), ['rank0'])
 })
 
 test('should search decomposed unicode with combining characters removed', t => {

--- a/test/label.js
+++ b/test/label.js
@@ -229,3 +229,29 @@ test('strings of two or more digits in labels should be ignored', t => {
   t.plan(1)
   t.same(results.map(({ref}) => ref), ['rank0', 'rank1'])
 })
+
+test('"war" is not a separate token', t => {
+  const docs = [
+    {id: 'rank0', label: 'Civil War (1861 - 1865)'},
+    {id: 'rank1', label: 'Civil War 1861-1865'},
+    {id: 'unranked0', label: 'Xianfeng, 1850-1861'},
+    {id: 'unranked1', label: 'Some Other War, 1839-1861'},
+    {id: 'unranked2', label: 'Civil Wars'},
+  ]
+  const results = label.index(docs).search('Civil War 1861-1865')
+  t.plan(1)
+  t.same(results.map(({ref}) => ref), ['rank0', 'rank1'])
+})
+
+test('"wars" is not a separate token', t => {
+  const docs = [
+    {id: 'unranked0', label: 'Civil War (1861 - 1865)'},
+    {id: 'unranked1', label: 'Civil War 1861-1865'},
+    {id: 'unranked2', label: 'Xianfeng, 1850-1861'},
+    {id: 'unranked3', label: 'Some Other War, 1839-1861'},
+    {id: 'rank0', label: 'Civil Wars'},
+  ]
+  const results = label.index(docs).search('Civil Wars')
+  t.plan(1)
+  t.same(results.map(({ref}) => ref), ['rank0'])
+})

--- a/test/temporal.js
+++ b/test/temporal.js
@@ -25,7 +25,7 @@ test('scoring intervals for interval queries', t => {
 
 test('point query', t => {
   const docs = [
-    {id: 'rank1', start: {in: {year: 300}}, stop: {in: {year: 500}}},
+    {id: 'rank1', start: {in: {year: 250}}, stop: {in: {year: 500}}},
     {id: 'rank0', start: {in: {year: 100}}, stop: {in: {year: 300}}},
     {id: 'unranked', start: {in: {year: 500}}, stop: {in: {year: 700}}}
   ]
@@ -36,7 +36,7 @@ test('point query', t => {
 
 test('point query disguised as interval', t => {
   const docs = [
-    {id: 'rank1', start: {in: {year: 300}}, stop: {in: {year: 500}}},
+    {id: 'rank1', start: {in: {year: 250}}, stop: {in: {year: 500}}},
     {id: 'rank0', start: {in: {year: 100}}, stop: {in: {year: 300}}},
     {id: 'unranked', start: {in: {year: 500}}, stop: {in: {year: 700}}}
   ]

--- a/test/tokenize.js
+++ b/test/tokenize.js
@@ -36,6 +36,14 @@ test('except before Roman numerals or after phase modifiers', t => {
   t.same(tokenize('Early Early Bronze'), ['early early bronze'])
 })
 
+test('or before "war"', t => {
+  t.plan(4)
+  t.same(tokenize('Civil War'), ['civil war'])
+  t.same(tokenize('War of Independence'), ['war', 'of', 'independence'])
+  t.same(tokenize('Servile Wars, 135-71 B.C'), ['servile wars', 'b.c'])
+  t.same(tokenize('South African War, 1899-1902'), ['south', 'african war'])
+})
+
 test('years are separators', t => {
   t.plan(8)
   t.same(tokenize('Alexander 1501-1506'), ['alexander'])

--- a/test/tokenize.js
+++ b/test/tokenize.js
@@ -1,0 +1,82 @@
+"use strict";
+
+const test = require('tape')
+    , tokenize = require('../src/tokenize')
+
+test('nil returns empty token array', t => {
+  t.plan(2)
+  t.same(tokenize(null), [])
+  t.same(tokenize(undefined), [])
+})
+
+test('handles arrays', t => {
+  t.plan(1)
+  t.same(tokenize(['one two', 'three four']), ['one', 'two', 'three', 'four'])
+})
+
+test('spaces are separators', t => {
+  t.plan(1)
+  t.same(tokenize('Bronze Age'), ['bronze', 'age'])
+})
+
+test('except before Roman numerals or after phase modifiers', t => {
+  t.plan(13)
+  t.same(tokenize('Early Bronze III'), ['early bronze iii'])
+  t.same(tokenize('Late Helladic IIIA'), ['late helladic iiia'])
+  t.same(tokenize('Late Minoan IIIA1'), ['late minoan iiia1'])
+  t.same(tokenize('Late Minoan IIIA2'), ['late minoan iiia2'])
+  t.same(tokenize('Late Minoan IIIB'), ['late minoan iiib'])
+  t.same(tokenize('Late Minoan IIIB1'), ['late minoan iiib1'])
+  t.same(tokenize('Late Minoan IIIB2'), ['late minoan iiib2'])
+  t.same(tokenize('Late Minoan IIIC'), ['late minoan iiic'])
+  t.same(tokenize('Early Bronze Age'), ['early bronze', 'age'])
+  t.same(tokenize('Late Helladic'), ['late helladic'])
+  t.same(tokenize('Middle Neolithic'), ['middle neolithic'])
+  t.same(tokenize('Early Early Early'), ['early early early'])
+  t.same(tokenize('Early Early Bronze'), ['early early bronze'])
+})
+
+test('years are separators', t => {
+  t.plan(8)
+  t.same(tokenize('Alexander 1501-1506'), ['alexander'])
+  t.same(tokenize('Alexander, 1501-1506'), ['alexander'])
+  t.same(tokenize('Alexander (1501-1506)'), ['alexander'])
+  t.same(tokenize('Alexander (1501 - 1506)'), ['alexander'])
+  t.same(tokenize('Alexander, 501-506'), ['alexander'])
+  t.same(
+    tokenize('Athenian supremacy, 479-431 B.C.'),
+    ['athenian', 'supremacy', 'b.c.']
+  )
+  t.same(tokenize('Bourbons, 1700-'), ['bourbons'])
+  t.same(
+    tokenize("Li Tzu ch'eng Rebellion, 1628-1645"),
+    ['li', 'tzu', "ch'eng", 'rebellion']
+  )
+})
+
+test('unicode', t => {
+  t.plan(2)
+  t.same(
+    tokenize('Ύστερη Εποχή του Χαλκού'),
+    ['ύστερη', 'εποχή', 'του', 'χαλκού']
+  )
+  t.same(
+    tokenize('Пізньоантичний період'),
+    ['пізньоантичний', 'період']
+  )
+})
+
+test('LCSH', t => {
+  t.plan(1)
+  t.same(
+    tokenize('18th Century::2nd/3rd quarter (1725 - 1774)'),
+    ['18th', 'century', '2nd/3rd', 'quarter']
+  )
+})
+
+test('arabic numeral phases converted to Roman', t => {
+  t.plan(3)
+  t.same(tokenize('Early Bronze 2'), ['early bronze ii'])
+  t.same(tokenize('Weeden Island 5'), ['weeden', 'island v'])
+  t.same(tokenize('Ninevite 5 Painted'), ['ninevite v', 'painted'])
+})

--- a/test/tokenize.js
+++ b/test/tokenize.js
@@ -40,8 +40,15 @@ test('or before "war"', t => {
   t.plan(4)
   t.same(tokenize('Civil War'), ['civil war'])
   t.same(tokenize('War of Independence'), ['war', 'of', 'independence'])
-  t.same(tokenize('Servile Wars, 135-71 B.C'), ['servile wars', 'b.c'])
-  t.same(tokenize('South African War, 1899-1902'), ['south', 'african war'])
+  t.same(tokenize('Servile Wars, 135-71 B.C'), ['servile wars', 'bc'])
+  t.same(tokenize('South African War, 1899-1902'), ['south african war'])
+})
+
+test('or before "rebellion"', t => {
+  t.plan(2)
+  t.same(tokenize('Nian Rebellion'), ['nian rebellion'])
+  t.same(tokenize('Rebellion of Zebrzydowski'),
+    ['rebellion', 'of', 'zebrzydowski'])
 })
 
 test('years are separators', t => {
@@ -53,24 +60,24 @@ test('years are separators', t => {
   t.same(tokenize('Alexander, 501-506'), ['alexander'])
   t.same(
     tokenize('Athenian supremacy, 479-431 B.C.'),
-    ['athenian', 'supremacy', 'b.c.']
+    ['athenian', 'supremacy', 'bc']
   )
   t.same(tokenize('Bourbons, 1700-'), ['bourbons'])
   t.same(
     tokenize("Li Tzu ch'eng Rebellion, 1628-1645"),
-    ['li', 'tzu', "ch'eng", 'rebellion']
+    ['li', 'tzu', 'cheng rebellion']
   )
 })
 
-test('unicode', t => {
+test('diacritics should be removed', t => {
   t.plan(2)
   t.same(
     tokenize('Ύστερη Εποχή του Χαλκού'),
-    ['ύστερη', 'εποχή', 'του', 'χαλκού']
+    ['υστερη', 'εποχη', 'του', 'χαλκου']
   )
   t.same(
     tokenize('Пізньоантичний період'),
-    ['пізньоантичний', 'період']
+    ['пізньоантичнии', 'період']
   )
 })
 
@@ -78,7 +85,7 @@ test('LCSH', t => {
   t.plan(1)
   t.same(
     tokenize('18th Century::2nd/3rd quarter (1725 - 1774)'),
-    ['18th', 'century', '2nd/3rd', 'quarter']
+    ['18th century', '2nd 3rd quarter']
   )
 })
 
@@ -87,4 +94,11 @@ test('arabic numeral phases converted to Roman', t => {
   t.same(tokenize('Early Bronze 2'), ['early bronze ii'])
   t.same(tokenize('Weeden Island 5'), ['weeden', 'island v'])
   t.same(tokenize('Ninevite 5 Painted'), ['ninevite v', 'painted'])
+})
+
+test('ordinal modifiers included in token', t => {
+  t.plan(3)
+  t.same(tokenize('1st Post'), ['1st post'])
+  t.same(tokenize('2nd/3rd quarter'), ['2nd 3rd quarter'])
+  t.same(tokenize('18th Century'), ['18th century'])
 })


### PR DESCRIPTION
Basic strategy is to identify modifying prefixes (e.g. "Anglo", "pre") and period category terms ("Empire", "Revolts") and not tokenize these separately.